### PR TITLE
feat: create Next.js portfolio

### DIFF
--- a/portfolio/components/Navbar.tsx
+++ b/portfolio/components/Navbar.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { FaBars } from 'react-icons/fa';
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false);
+  return (
+    <header className="fixed top-0 left-0 w-full bg-white shadow z-50">
+      <nav className="max-w-5xl mx-auto flex items-center justify-between p-4">
+        <a href="#home" className="font-bold text-lg">Alonso Cruz</a>
+        <button
+          className="md:hidden"
+          onClick={() => setOpen(!open)}
+          aria-label="Abrir menú"
+        >
+          <FaBars />
+        </button>
+        <ul className={`md:flex md:space-x-6 ${open ? 'block' : 'hidden'} md:block`}>
+          <li><a href="#about" className="block py-2">Sobre mí</a></li>
+          <li><a href="#projects" className="block py-2">Proyectos</a></li>
+          <li><a href="#certs" className="block py-2">Certificaciones</a></li>
+          <li><a href="#experience" className="block py-2">Experiencia</a></li>
+          <li><a href="#contact" className="block py-2">Contacto</a></li>
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/portfolio/components/ProjectCard.tsx
+++ b/portfolio/components/ProjectCard.tsx
@@ -1,0 +1,29 @@
+import { motion } from 'framer-motion';
+
+interface Props {
+  title: string;
+  description: string;
+  tech: string;
+  link: string;
+}
+
+export default function ProjectCard({ title, description, tech, link }: Props) {
+  return (
+    <motion.div
+      whileHover={{ scale: 1.02 }}
+      className="p-6 border rounded shadow bg-white flex flex-col"
+    >
+      <h3 className="text-xl font-semibold mb-2">{title}</h3>
+      <p className="mb-2 flex-1">{description}</p>
+      <p className="text-sm text-gray-500 mb-4">{tech}</p>
+      <a
+        href={link}
+        target="_blank"
+        rel="noopener"
+        className="mt-auto btn-primary w-max"
+      >
+        Ver proyecto
+      </a>
+    </motion.div>
+  );
+}

--- a/portfolio/next-env.d.ts
+++ b/portfolio/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited

--- a/portfolio/next.config.js
+++ b/portfolio/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "framer-motion": "10.16.4",
+    "react-icons": "4.10.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.24",
+    "tailwindcss": "3.3.3",
+    "typescript": "5.1.3",
+    "@types/react": "18.2.7",
+    "@types/node": "20.4.2"
+  }
+}

--- a/portfolio/pages/_app.tsx
+++ b/portfolio/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/portfolio/pages/index.tsx
+++ b/portfolio/pages/index.tsx
@@ -1,0 +1,213 @@
+import Head from 'next/head';
+import { motion } from 'framer-motion';
+import Navbar from '../components/Navbar';
+import ProjectCard from '../components/ProjectCard';
+import { FaLinkedin, FaGithub } from 'react-icons/fa';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>Alonso Gaspar Cruz Farías - Portafolio</title>
+        <meta
+          name="description"
+          content="Portafolio profesional de Alonso Gaspar Cruz Farías, Ingeniero en Informática."
+        />
+      </Head>
+      <Navbar />
+      <main className="pt-20">
+        {/* Home */}
+        <motion.section
+          id="home"
+          className="min-h-screen flex flex-col justify-center items-center text-center px-4"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <img
+            src="https://via.placeholder.com/160"
+            alt="Alonso Gaspar Cruz Farías"
+            className="w-40 h-40 rounded-full mb-4"
+          />
+          <h1 className="text-4xl font-bold mb-2">
+            Alonso Gaspar Cruz Farías
+          </h1>
+          <p className="mb-4 max-w-xl">
+            Ingeniero en Informática orientado al desarrollo de software,
+            liderazgo y servicio al cliente.
+          </p>
+          <div className="flex space-x-4">
+            <a
+              href="https://www.linkedin.com/in/alonsocruz/"
+              target="_blank"
+              rel="noopener"
+              className="btn-primary"
+            >
+              LinkedIn
+            </a>
+            <a href="mailto:alonsocruz@example.com" className="btn-primary">
+              Correo
+            </a>
+            <a href="tel:+56900000000" className="btn-primary">
+              Teléfono
+            </a>
+          </div>
+        </motion.section>
+
+        {/* Sobre mí */}
+        <motion.section
+          id="about"
+          className="py-20 bg-gray-100 px-4"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <h2 className="text-3xl font-semibold mb-6 text-center">Sobre mí</h2>
+          <p className="max-w-3xl mx-auto">
+            Estudiante de Ingeniería en Informática formado en Duoc UC y la
+            Universidad Diego Portales, ex alumno del Colegio Notre Dame. He
+            desarrollado habilidades de liderazgo y servicio al cliente,
+            destacando por mi compromiso, trabajo en equipo y aprendizaje
+            continuo.
+          </p>
+        </motion.section>
+
+        {/* Proyectos */}
+        <motion.section
+          id="projects"
+          className="py-20 px-4"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <h2 className="text-3xl font-semibold mb-8 text-center">Proyectos</h2>
+          <div className="grid md:grid-cols-2 gap-6 max-w-5xl mx-auto">
+            <ProjectCard
+              title="MasterbikesProject"
+              description="Plataforma web para arriendos y ventas de bicicletas con registro, catálogo y soporte."
+              tech="Django • SQLite • HTML • CSS • JS"
+              link="https://github.com/cruch5357/MasterbikesProject"
+            />
+            <ProjectCard
+              title="SantuarioCaelestis"
+              description="Sistema de información para la gestión de un santuario, con administración de entidades y usuarios."
+              tech="Django • SQLite • HTML • CSS • JS"
+              link="https://github.com/cruch5357/SantuarioCaelestis"
+            />
+            <ProjectCard
+              title="MoniCarro"
+              description="Aplicación móvil para monitorear el estado de un vehículo en tiempo real."
+              tech="Ionic Angular • Firebase"
+              link="https://github.com/cruch5357/MoniCarro"
+            />
+            <ProjectCard
+              title="RegistrApp"
+              description="Registro de asistencia con Ionic y Firebase orientado a instituciones educativas."
+              tech="Ionic Angular • Firebase"
+              link="https://github.com/ant000o/ProyectoIonic"
+            />
+          </div>
+        </motion.section>
+
+        {/* Certificaciones */}
+        <motion.section
+          id="certs"
+          className="py-20 bg-gray-100 px-4"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <h2 className="text-3xl font-semibold mb-6 text-center">
+            Certificaciones y habilidades
+          </h2>
+          <ul className="max-w-3xl mx-auto list-disc list-inside space-y-2">
+            <li>Microsoft Certified: Azure AI Fundamentals</li>
+            <li>Python Essentials 1</li>
+            <li>PCEP – Certified Entry-Level Python Programmer</li>
+            <li>Python • Ionic Angular • Firebase • MySQL • HTML • CSS • Git</li>
+          </ul>
+        </motion.section>
+
+        {/* Experiencia */}
+        <motion.section
+          id="experience"
+          className="py-20 px-4"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <h2 className="text-3xl font-semibold mb-6 text-center">
+            Experiencia profesional
+          </h2>
+          <ul className="max-w-3xl mx-auto list-disc list-inside space-y-2">
+            <li>Empresas La Polar – Ayudante de Navidad</li>
+            <li>Colegio Notre Dame – Centro de alumnos</li>
+          </ul>
+        </motion.section>
+
+        {/* Currículum */}
+        <motion.section
+          id="cv"
+          className="py-20 bg-gray-100 text-center px-4"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <h2 className="text-3xl font-semibold mb-6">Currículum</h2>
+          <a href="/cv.pdf" className="btn-primary" target="_blank" rel="noopener">
+            Descargar CV
+          </a>
+        </motion.section>
+
+        {/* Contacto */}
+        <motion.section
+          id="contact"
+          className="py-20 px-4"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <h2 className="text-3xl font-semibold mb-6 text-center">Contacto</h2>
+          <form className="max-w-xl mx-auto space-y-4">
+            <input
+              type="text"
+              placeholder="Nombre"
+              required
+              className="w-full border p-2 rounded"
+            />
+            <input
+              type="email"
+              placeholder="Correo"
+              required
+              className="w-full border p-2 rounded"
+            />
+            <textarea
+              placeholder="Mensaje"
+              required
+              className="w-full border p-2 rounded h-32"
+            />
+            <button type="submit" className="btn-primary w-full">Enviar</button>
+          </form>
+          <div className="flex justify-center space-x-6 mt-8 text-2xl">
+            <a
+              href="https://www.linkedin.com/in/alonsocruz/"
+              target="_blank"
+              rel="noopener"
+              aria-label="LinkedIn"
+            >
+              <FaLinkedin />
+            </a>
+            <a
+              href="https://github.com/cruch5357"
+              target="_blank"
+              rel="noopener"
+              aria-label="GitHub"
+            >
+              <FaGithub />
+            </a>
+          </div>
+        </motion.section>
+      </main>
+    </>
+  );
+}

--- a/portfolio/postcss.config.js
+++ b/portfolio/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/portfolio/public/cv.pdf
+++ b/portfolio/public/cv.pdf
@@ -1,0 +1,1 @@
+CV placeholder

--- a/portfolio/styles/globals.css
+++ b/portfolio/styles/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50 text-gray-800 scroll-smooth;
+}
+
+.btn-primary {
+  @apply px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition;
+}

--- a/portfolio/tailwind.config.js
+++ b/portfolio/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/portfolio/tsconfig.json
+++ b/portfolio/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js + TypeScript portfolio using Tailwind and Framer Motion
- add sections for bio, projects, certifications, experience, CV and contact
- include responsive navigation and project cards

## Testing
- `npm test`
- `cd proyect && npm test -- --watch=false` *(fails: no output, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bbabd2d9708332a0a9b36a45566b93